### PR TITLE
Added into_inner method to the sync compressors

### DIFF
--- a/src/lz4f/stream/comp/bufread.rs
+++ b/src/lz4f/stream/comp/bufread.rs
@@ -57,6 +57,11 @@ impl<R: BufRead> BufReadCompressor<R> {
             consumed: 0,
         })
     }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.device
+    }
 }
 
 impl<R: BufRead> Read for BufReadCompressor<R> {

--- a/src/lz4f/stream/comp/read.rs
+++ b/src/lz4f/stream/comp/read.rs
@@ -47,6 +47,11 @@ impl<R: Read> ReadCompressor<R> {
             inner: BufReadCompressor::with_dict(BufReader::new(reader), prefs, dict)?,
         })
     }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.inner.into_inner().into_inner()
+    }
 }
 
 impl<R: Read> Read for ReadCompressor<R> {

--- a/src/lz4f/stream/comp/write.rs
+++ b/src/lz4f/stream/comp/write.rs
@@ -47,7 +47,7 @@ impl<W: Write> WriteCompressor<W> {
         })
     }
 
-    /// Returns the owndership of the writer, fnishing the stream in the process.
+    /// Returns the ownership of the writer, finishing the stream in the process.
     pub fn into_inner(mut self) -> W {
         let _ = self.end();
         self.device.take().unwrap()

--- a/src/lz4f/stream/decomp/bufread.rs
+++ b/src/lz4f/stream/decomp/bufread.rs
@@ -76,6 +76,11 @@ impl<'a, R: BufRead> BufReadDecompressor<'a, R> {
             self.inner.decode_header_only(false);
         }
     }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.device
+    }
 }
 
 impl<R: BufRead> Read for BufReadDecompressor<'_, R> {

--- a/src/lz4f/stream/decomp/read.rs
+++ b/src/lz4f/stream/decomp/read.rs
@@ -61,6 +61,11 @@ impl<'a, R: Read> ReadDecompressor<'a, R> {
     pub fn read_frame_info(&mut self) -> std::io::Result<FrameInfo> {
         self.inner.read_frame_info()
     }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.inner.into_inner().into_inner()
+    }
 }
 
 impl<R: Read> Read for ReadDecompressor<'_, R> {

--- a/src/lz4f/stream/decomp/write.rs
+++ b/src/lz4f/stream/decomp/write.rs
@@ -63,6 +63,11 @@ impl<'a, W: Write> WriteDecompressor<'a, W> {
     pub fn decode_header_only(&mut self, flag: bool) {
         self.inner.decode_header_only(flag);
     }
+
+    /// Returns ownership of the writer.
+    pub fn into_inner(self) -> W {
+        self.device
+    }
 }
 
 impl<W: Write> Write for WriteDecompressor<'_, W> {


### PR DESCRIPTION
This is useful when dealing with owned readers & writers.