### PR TITLE
Replaced tokio dependency by async_std & futures_io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 pin-project = { version = "0.4.22", optional = true }
-tokio = { version = "0.2.22", optional = true }
+async-std = { version = "1.6", optional = true }
+futures-lite = { version = "0.1.10", optional = true }
 
 [dev-dependencies]
 assert_fs = "1.0.0"
@@ -30,10 +31,10 @@ lazy_static = "1.4.0"
 rand = { version = "0.7.3", features = ["small_rng"] }
 rayon = "1.3.1"
 static_assertions = "1.1.0"
-tokio = { version = "0.2.22", features = ["fs", "rt-core", "rt-threaded", "macros"] }
+smol = "0.3.3"
 
 [build-dependencies]
 cc = { version = "1.0.58", features = ["parallel"] }
 
 [features]
-tokio-io = ["tokio/io-util", "pin-project"]
+async-io = ["async-std", "pin-project", "futures-lite"]

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ lzzzz = "0.3"
 
 ### Asynchronous I/O
 
-The `tokio-io` feature flag enables asynchronous LZ4F streaming compressors and decompressors.
+The `async-io` feature flag enables asynchronous LZ4F streaming compressors and decompressors.
 
 ```toml
 [dependencies]
-lzzzz = { version = "0.3", features = ["tokio-io"] }
+lzzzz = { version = "0.3", features = ["async-io"] }
 ```
 
 ## Examples
@@ -115,17 +115,17 @@ r.read_to_end(&mut buf)?;
 
 ### Asynchronous Streaming Mode
 
-Requires `tokio-io` feature flag
+Requires `async-io` feature flag
 
 ```rust
 use lzzzz::lz4f::{AsyncWriteCompressor, AsyncReadDecompressor};
-use tokio::{fs::File, prelude::*};
+use async_std::{fs::File, prelude::*};
 
 // LZ4F AsyncWrite-based compression
 let mut f = File::create("foo.lz4").await?;
 let mut w = AsyncWriteCompressor::new(&mut f, Default::default())?;
 w.write_all(b"Hello world!").await?;
-w.shutdown().await?;
+w.close().await?;
 
 // LZ4F AsyncRead-based decompression
 let mut f = File::open("foo.lz4").await?;

--- a/src/lz4f/mod.rs
+++ b/src/lz4f/mod.rs
@@ -2,10 +2,10 @@
 //!
 //! # Asynchronous I/O
 //!
-//! The `tokio-io` feature flag enables asynchronous streaming compressors and decompressors.
+//! The `async-io` feature flag enables asynchronous streaming compressors and decompressors.
 //!
 //! ```toml
-//! lzzzz = { version = "...", features = ["tokio-io"] }
+//! lzzzz = { version = "...", features = ["async-io"] }
 //! ```
 
 mod api;

--- a/src/lz4f/stream/comp/async_bufread.rs
+++ b/src/lz4f/stream/comp/async_bufread.rs
@@ -1,14 +1,14 @@
-#![cfg(feature = "tokio-io")]
+#![cfg(feature = "async-io")]
 
 use super::{Compressor, Dictionary, Preferences};
 use crate::lz4f::Result;
+use futures_lite::{AsyncBufRead, AsyncRead};
 use pin_project::pin_project;
 use std::{
-    cmp,
+    cmp, io,
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::io::{AsyncBufRead, AsyncRead};
 
 /// The [`AsyncBufRead`]-based streaming compressor.
 ///
@@ -24,10 +24,9 @@ use tokio::io::{AsyncBufRead, AsyncRead};
 /// #
 /// # tmp_dir.child("foo.txt").write_str("Hello").unwrap();
 /// #
-/// # let mut rt = tokio::runtime::Runtime::new().unwrap();
-/// # rt.block_on(async {
+/// # smol::run(async {
 /// use lzzzz::lz4f::AsyncBufReadCompressor;
-/// use tokio::{fs::File, io::BufReader, prelude::*};
+/// use async_std::{fs::File, io::BufReader, prelude::*};
 ///
 /// let mut f = File::open("foo.txt").await?;
 /// let mut b = BufReader::new(f);
@@ -35,14 +34,14 @@ use tokio::io::{AsyncBufRead, AsyncRead};
 ///
 /// let mut buf = Vec::new();
 /// r.read_to_end(&mut buf).await?;
-/// # Ok::<(), tokio::io::Error>(())
+/// # Ok::<(), std::io::Error>(())
 /// # }).unwrap();
 /// # tmp_dir.close().unwrap();
 /// ```
 ///
-/// [`AsyncBufRead`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufRead.html
+/// [`AsyncBufRead`]: https://docs.rs/futures-io/0.3.5/futures_io/trait.AsyncBufRead.html
 
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-io")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-io")))]
 #[pin_project]
 pub struct AsyncBufReadCompressor<R: AsyncBufRead + Unpin> {
     #[pin]
@@ -82,7 +81,7 @@ impl<R: AsyncBufRead + Unpin> AsyncBufReadCompressor<R> {
         })
     }
 
-    fn fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<tokio::io::Result<()>> {
+    fn fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         let mut me = self.project();
         let inner_buf = match me.device.as_mut().poll_fill_buf(cx) {
             Poll::Pending => {
@@ -113,7 +112,7 @@ impl<R: AsyncBufRead + Unpin> AsyncRead for AsyncBufReadCompressor<R> {
         mut self: Pin<&mut Self>,
         cx: &mut Context,
         buf: &mut [u8],
-    ) -> Poll<tokio::io::Result<usize>> {
+    ) -> Poll<io::Result<usize>> {
         let mut me = Pin::new(&mut *self);
         if let State::None = me.state {
             me.state = State::Read;
@@ -138,7 +137,7 @@ impl<R: AsyncBufRead + Unpin> AsyncRead for AsyncBufReadCompressor<R> {
 }
 
 impl<R: AsyncBufRead + Unpin> AsyncBufRead for AsyncBufReadCompressor<R> {
-    fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<tokio::io::Result<&[u8]>> {
+    fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<&[u8]>> {
         let mut me = Pin::new(&mut *self);
         if let State::None = me.state {
             me.state = State::FillBuf;

--- a/src/lz4f/stream/comp/mod.rs
+++ b/src/lz4f/stream/comp/mod.rs
@@ -17,7 +17,7 @@ use crate::lz4f::{
     Dictionary, Preferences,
 };
 
-#[cfg(feature = "tokio-io")]
+#[cfg(feature = "async-io")]
 pub use {async_bufread::*, async_read::*, async_write::*};
 
 pub(crate) struct Compressor {

--- a/src/lz4f/stream/decomp/async_bufread.rs
+++ b/src/lz4f/stream/decomp/async_bufread.rs
@@ -1,14 +1,15 @@
-#![cfg(feature = "tokio-io")]
+#![cfg(feature = "async-io")]
 
 use super::Decompressor;
 use crate::lz4f::{FrameInfo, Result};
+use futures_lite::{AsyncBufRead, AsyncRead, AsyncReadExt};
 use pin_project::pin_project;
 use std::{
     borrow::Cow,
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt};
 
 /// The [`AsyncBufRead`]-based streaming decompressor.
 ///
@@ -26,10 +27,9 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt};
 /// # lzzzz::lz4f::compress_to_vec(b"Hello world!", &mut buf, &Default::default()).unwrap();
 /// # tmp_dir.child("foo.lz4").write_binary(&buf).unwrap();
 /// #
-/// # let mut rt = tokio::runtime::Runtime::new().unwrap();
-/// # rt.block_on(async {
+/// # smol::run(async {
 /// use lzzzz::lz4f::AsyncBufReadDecompressor;
-/// use tokio::{fs::File, io::BufReader, prelude::*};
+/// use async_std::{fs::File, io::BufReader, prelude::*};
 ///
 /// let mut f = File::open("foo.lz4").await?;
 /// let mut b = BufReader::new(f);
@@ -38,14 +38,14 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt};
 /// let mut buf = Vec::new();
 /// r.read_frame_info().await?;
 /// r.read_to_end(&mut buf).await?;
-/// # Ok::<(), tokio::io::Error>(())
+/// # Ok::<(), std::io::Error>(())
 /// # }).unwrap();
 /// # tmp_dir.close().unwrap();
 /// ```
 ///
-/// [`AsyncBufRead`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufRead.html
+/// [`AsyncBufRead`]: https://docs.rs/futures-io/0.3.5/futures_io/trait.AsyncBufRead.html
 
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-io")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-io")))]
 #[pin_project]
 pub struct AsyncBufReadDecompressor<'a, R: AsyncBufRead + Unpin> {
     #[pin]
@@ -76,7 +76,7 @@ impl<'a, R: AsyncBufRead + Unpin> AsyncBufReadDecompressor<'a, R> {
     ///
     /// Calling this function before any `AsyncRead` or `AsyncBufRead` operations
     /// does not consume the frame body.
-    pub async fn read_frame_info(&mut self) -> tokio::io::Result<FrameInfo> {
+    pub async fn read_frame_info(&mut self) -> io::Result<FrameInfo> {
         loop {
             if let Some(frame) = self.inner.frame_info() {
                 return Ok(frame);
@@ -87,7 +87,7 @@ impl<'a, R: AsyncBufRead + Unpin> AsyncBufReadDecompressor<'a, R> {
         }
     }
 
-    fn fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<tokio::io::Result<()>> {
+    fn fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         let mut me = self.project();
         let inner_buf = match me.device.as_mut().poll_fill_buf(cx) {
             Poll::Pending => {
@@ -110,7 +110,7 @@ impl<'a, R: AsyncBufRead + Unpin> AsyncRead for AsyncBufReadDecompressor<'a, R> 
         mut self: Pin<&mut Self>,
         cx: &mut Context,
         buf: &mut [u8],
-    ) -> Poll<tokio::io::Result<usize>> {
+    ) -> Poll<io::Result<usize>> {
         if let Poll::Pending = Pin::new(&mut *self).fill_buf(cx)? {
             Poll::Pending
         } else {
@@ -128,7 +128,7 @@ impl<'a, R: AsyncBufRead + Unpin> AsyncRead for AsyncBufReadDecompressor<'a, R> 
 }
 
 impl<'a, R: AsyncBufRead + Unpin> AsyncBufRead for AsyncBufReadDecompressor<'a, R> {
-    fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<tokio::io::Result<&[u8]>> {
+    fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<&[u8]>> {
         if let Poll::Pending = Pin::new(&mut *self).fill_buf(cx)? {
             Poll::Pending
         } else {

--- a/src/lz4f/stream/decomp/async_read.rs
+++ b/src/lz4f/stream/decomp/async_read.rs
@@ -1,14 +1,16 @@
-#![cfg(feature = "tokio-io")]
+#![cfg(feature = "async-io")]
 
 use super::AsyncBufReadDecompressor;
 use crate::lz4f::{FrameInfo, Result};
+use async_std::io::BufReader;
+use futures_lite::AsyncRead;
 use pin_project::pin_project;
 use std::{
     borrow::Cow,
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::io::{AsyncRead, BufReader};
 
 /// The [`AsyncRead`]-based streaming decompressor.
 ///
@@ -26,24 +28,23 @@ use tokio::io::{AsyncRead, BufReader};
 /// # lzzzz::lz4f::compress_to_vec(b"Hello world!", &mut buf, &Default::default()).unwrap();
 /// # tmp_dir.child("foo.lz4").write_binary(&buf).unwrap();
 /// #
-/// # let mut rt = tokio::runtime::Runtime::new().unwrap();
-/// # rt.block_on(async {
+/// # smol::run(async {
 /// use lzzzz::lz4f::AsyncReadDecompressor;
-/// use tokio::{fs::File, prelude::*};
+/// use async_std::{fs::File, prelude::*};
 ///
 /// let mut f = File::open("foo.lz4").await?;
 /// let mut r = AsyncReadDecompressor::new(&mut f)?;
 ///
 /// let mut buf = Vec::new();
 /// r.read_to_end(&mut buf).await?;
-/// # Ok::<(), tokio::io::Error>(())
+/// # Ok::<(), std::io::Error>(())
 /// # }).unwrap();
 /// # tmp_dir.close().unwrap();
 /// ```
 ///
-/// [`AsyncRead`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html
+/// [`AsyncRead`]: https://docs.rs/futures-io/0.3.5/futures_io/trait.AsyncRead.html
 
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-io")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-io")))]
 #[pin_project]
 pub struct AsyncReadDecompressor<'a, R: AsyncRead + Unpin> {
     #[pin]
@@ -70,7 +71,7 @@ impl<'a, R: AsyncRead + Unpin> AsyncReadDecompressor<'a, R> {
     ///
     /// Calling this function before any `AsyncRead` operations
     /// does not consume the frame body.
-    pub async fn read_frame_info(&mut self) -> tokio::io::Result<FrameInfo> {
+    pub async fn read_frame_info(&mut self) -> io::Result<FrameInfo> {
         self.inner.read_frame_info().await
     }
 }
@@ -80,7 +81,7 @@ impl<'a, R: AsyncRead + Unpin> AsyncRead for AsyncReadDecompressor<'a, R> {
         self: Pin<&mut Self>,
         cx: &mut Context,
         buf: &mut [u8],
-    ) -> Poll<tokio::io::Result<usize>> {
+    ) -> Poll<io::Result<usize>> {
         self.project().inner.poll_read(cx, buf)
     }
 }

--- a/src/lz4f/stream/decomp/mod.rs
+++ b/src/lz4f/stream/decomp/mod.rs
@@ -10,7 +10,7 @@ pub use bufread::*;
 pub use read::*;
 pub use write::*;
 
-#[cfg(feature = "tokio-io")]
+#[cfg(feature = "async-io")]
 pub use {async_bufread::*, async_read::*, async_write::*};
 
 use crate::{

--- a/tests/lz4f_async_stream.rs
+++ b/tests/lz4f_async_stream.rs
@@ -366,7 +366,7 @@ mod async_bufread_decompressor {
     }
 
     #[test]
-    async fn small_buffer() {
+    fn small_buffer() {
         join_all(lz4f_test_set().map(|(src, prefs)| async move {
             let mut comp_buf = Vec::new();
             let mut decomp_buf = Vec::new();

--- a/tests/lz4f_async_stream.rs
+++ b/tests/lz4f_async_stream.rs
@@ -1,10 +1,10 @@
-#![cfg(feature = "tokio-io")]
+#![cfg(feature = "async-io")]
 
+use async_std::{fs::File, io::BufReader};
 use futures::future::join_all;
 use lzzzz::{lz4f, lz4f::*};
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
 use static_assertions::assert_impl_all;
-use tokio::{fs::File, io::BufReader};
 
 mod common;
 use common::lz4f_test_set;
@@ -18,463 +18,498 @@ assert_impl_all!(lz4f::AsyncWriteDecompressor<File>: Send);
 
 mod async_read_compressor {
     use super::*;
+    use futures_lite::AsyncReadExt;
     use lzzzz::lz4f::AsyncReadCompressor;
-    use tokio::io::AsyncReadExt;
 
-    #[tokio::test]
-    async fn default() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            {
-                let mut src = src.as_ref();
-                let mut r = AsyncReadCompressor::new(&mut src, prefs).unwrap();
-                r.read_to_end(&mut comp_buf).await.unwrap();
-            }
-            assert_eq!(
-                lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
-                decomp_buf.len()
-            );
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
+    #[test]
+    fn default() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                {
+                    let mut src = src.as_ref();
+                    let mut r = AsyncReadCompressor::new(&mut src, prefs).unwrap();
+                    r.read_to_end(&mut comp_buf).await.unwrap();
+                }
+                assert_eq!(
+                    lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
+                    decomp_buf.len()
+                );
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
     }
 
-    #[tokio::test]
-    async fn random_chunk() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            {
-                let mut src = src.as_ref();
-                let mut r = AsyncReadCompressor::new(&mut src, prefs).unwrap();
+    #[test]
+    fn random_chunk() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                {
+                    let mut src = src.as_ref();
+                    let mut r = AsyncReadCompressor::new(&mut src, prefs).unwrap();
 
-                let mut offset = 0;
-                let mut rng = SmallRng::seed_from_u64(0);
+                    let mut offset = 0;
+                    let mut rng = SmallRng::seed_from_u64(0);
 
-                loop {
-                    if offset >= comp_buf.len() {
-                        comp_buf.resize_with(offset + 1024, Default::default);
+                    loop {
+                        if offset >= comp_buf.len() {
+                            comp_buf.resize_with(offset + 1024, Default::default);
+                        }
+                        let len = rng.gen_range(0, comp_buf.len() - offset + 1);
+                        let dst = &mut comp_buf[offset..][..len];
+                        let len = r.read(dst).await.unwrap();
+                        if !dst.is_empty() && len == 0 {
+                            break;
+                        }
+                        offset += len;
                     }
-                    let len = rng.gen_range(0, comp_buf.len() - offset + 1);
-                    let dst = &mut comp_buf[offset..][..len];
-                    let len = r.read(dst).await.unwrap();
-                    if !dst.is_empty() && len == 0 {
-                        break;
-                    }
-                    offset += len;
                 }
-            }
-            assert_eq!(
-                lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
-                decomp_buf.len()
-            );
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
+                assert_eq!(
+                    lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
+                    decomp_buf.len()
+                );
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
     }
 }
 
 mod async_bufread_compressor {
     use super::*;
+    use futures_lite::AsyncReadExt;
     use lzzzz::lz4f::AsyncBufReadCompressor;
-    use tokio::io::AsyncReadExt;
 
-    #[tokio::test]
-    async fn default() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            {
-                let mut src = src.as_ref();
-                let mut r = AsyncBufReadCompressor::new(&mut src, prefs).unwrap();
-                r.read_to_end(&mut comp_buf).await.unwrap();
-            }
-            assert_eq!(
-                lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
-                decomp_buf.len()
-            );
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
+    #[test]
+    fn default() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                {
+                    let mut src = src.as_ref();
+                    let mut r = AsyncBufReadCompressor::new(&mut src, prefs).unwrap();
+                    r.read_to_end(&mut comp_buf).await.unwrap();
+                }
+                assert_eq!(
+                    lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
+                    decomp_buf.len()
+                );
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
     }
 
-    #[tokio::test]
-    async fn random_chunk() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            {
-                let mut src = src.as_ref();
-                let mut r = AsyncBufReadCompressor::new(&mut src, prefs).unwrap();
+    #[test]
+    fn random_chunk() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                {
+                    let mut src = src.as_ref();
+                    let mut r = AsyncBufReadCompressor::new(&mut src, prefs).unwrap();
 
-                let mut offset = 0;
-                let mut rng = SmallRng::seed_from_u64(0);
+                    let mut offset = 0;
+                    let mut rng = SmallRng::seed_from_u64(0);
 
-                loop {
-                    if offset >= comp_buf.len() {
-                        comp_buf.resize_with(offset + 1024, Default::default);
+                    loop {
+                        if offset >= comp_buf.len() {
+                            comp_buf.resize_with(offset + 1024, Default::default);
+                        }
+                        let len = rng.gen_range(0, comp_buf.len() - offset + 1);
+                        let dst = &mut comp_buf[offset..][..len];
+                        let len = r.read(dst).await.unwrap();
+                        if !dst.is_empty() && len == 0 {
+                            break;
+                        }
+                        offset += len;
                     }
-                    let len = rng.gen_range(0, comp_buf.len() - offset + 1);
-                    let dst = &mut comp_buf[offset..][..len];
-                    let len = r.read(dst).await.unwrap();
-                    if !dst.is_empty() && len == 0 {
-                        break;
-                    }
-                    offset += len;
                 }
-            }
-            assert_eq!(
-                lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
-                decomp_buf.len()
-            );
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
+                assert_eq!(
+                    lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
+                    decomp_buf.len()
+                );
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
     }
 }
 
 mod async_write_compressor {
     use super::*;
     use futures::future::join_all;
+    use futures_lite::AsyncWriteExt;
     use lzzzz::lz4f::AsyncWriteCompressor;
-    use tokio::io::AsyncWriteExt;
 
-    #[tokio::test]
-    async fn default() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            {
-                let mut w = AsyncWriteCompressor::new(&mut comp_buf, prefs).unwrap();
-                w.write_all(&src).await.unwrap();
-                w.shutdown().await.unwrap();
-            }
-            assert_eq!(
-                lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
-                decomp_buf.len()
-            );
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
+    #[test]
+    fn default() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                {
+                    let mut w = AsyncWriteCompressor::new(&mut comp_buf, prefs).unwrap();
+                    w.write_all(&src).await.unwrap();
+                    w.close().await.unwrap();
+                }
+                assert_eq!(
+                    lz4f::decompress_to_vec(&comp_buf, &mut decomp_buf).unwrap(),
+                    decomp_buf.len()
+                );
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
     }
 }
 
 mod async_read_decompressor {
     use super::*;
     use futures::future::join_all;
+    use futures_lite::AsyncReadExt;
     use lzzzz::lz4f::{AsyncReadDecompressor, WriteCompressor};
     use std::io::Write;
-    use tokio::io::AsyncReadExt;
 
-    #[tokio::test]
-    async fn default() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut src = comp_buf.as_slice();
-                let mut r = AsyncReadDecompressor::new(&mut src).unwrap();
-                r.read_to_end(&mut decomp_buf).await.unwrap();
-            }
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
-    }
-
-    #[tokio::test]
-    async fn dictionary() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            let dict = SmallRng::seed_from_u64(0)
-                .sample_iter(Standard)
-                .take(64_000)
-                .collect::<Vec<_>>();
-            {
-                let mut w = WriteCompressor::with_dict(
-                    &mut comp_buf,
-                    prefs,
-                    Dictionary::new(&dict).unwrap(),
-                )
-                .unwrap();
-                w.write_all(&src).unwrap();
-            }
-            {
-                let mut src = comp_buf.as_slice();
-                let mut r = AsyncReadDecompressor::new(&mut src).unwrap();
+    #[test]
+    fn default() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
                 assert_eq!(
-                    r.read_frame_info().await.unwrap().dict_id(),
-                    prefs.frame_info().dict_id()
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
                 );
-                r.set_dict(&dict);
-                r.read_to_end(&mut decomp_buf).await.unwrap();
-            }
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
+                {
+                    let mut src = comp_buf.as_slice();
+                    let mut r = AsyncReadDecompressor::new(&mut src).unwrap();
+                    r.read_to_end(&mut decomp_buf).await.unwrap();
+                }
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
     }
 
-    #[tokio::test]
-    async fn random_chunk() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = vec![0; src.len()];
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut src = comp_buf.as_slice();
-                let mut r = AsyncReadDecompressor::new(&mut src).unwrap();
-
-                let mut offset = 0;
-                let mut rng = SmallRng::seed_from_u64(0);
-
-                let dst_len = decomp_buf.len();
-                while offset < dst_len {
-                    let dst = &mut decomp_buf[offset..][..rng.gen_range(0, dst_len - offset + 1)];
-                    let len = r.read(dst).await.unwrap();
-                    assert!(dst.is_empty() || len > 0);
-                    offset += len;
+    #[test]
+    fn dictionary() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                let dict = SmallRng::seed_from_u64(0)
+                    .sample_iter(Standard)
+                    .take(64_000)
+                    .collect::<Vec<_>>();
+                {
+                    let mut w = WriteCompressor::with_dict(
+                        &mut comp_buf,
+                        prefs,
+                        Dictionary::new(&dict).unwrap(),
+                    )
+                    .unwrap();
+                    w.write_all(&src).unwrap();
                 }
-            }
-            assert_eq!(decomp_buf.len(), src.len());
-        }))
-        .await;
+                {
+                    let mut src = comp_buf.as_slice();
+                    let mut r = AsyncReadDecompressor::new(&mut src).unwrap();
+                    assert_eq!(
+                        r.read_frame_info().await.unwrap().dict_id(),
+                        prefs.frame_info().dict_id()
+                    );
+                    r.set_dict(&dict);
+                    r.read_to_end(&mut decomp_buf).await.unwrap();
+                }
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
+    }
+
+    #[test]
+    fn random_chunk() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = vec![0; src.len()];
+                assert_eq!(
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
+                );
+                {
+                    let mut src = comp_buf.as_slice();
+                    let mut r = AsyncReadDecompressor::new(&mut src).unwrap();
+
+                    let mut offset = 0;
+                    let mut rng = SmallRng::seed_from_u64(0);
+
+                    let dst_len = decomp_buf.len();
+                    while offset < dst_len {
+                        let dst =
+                            &mut decomp_buf[offset..][..rng.gen_range(0, dst_len - offset + 1)];
+                        let len = r.read(dst).await.unwrap();
+                        assert!(dst.is_empty() || len > 0);
+                        offset += len;
+                    }
+                }
+                assert_eq!(decomp_buf.len(), src.len());
+            }))
+            .await;
+        })
     }
 }
 
 mod async_bufread_decompressor {
     use super::*;
     use futures::future::join_all;
+    use futures_lite::AsyncReadExt;
     use lzzzz::lz4f::{AsyncBufReadDecompressor, WriteCompressor};
     use std::io::Write;
-    use tokio::io::AsyncReadExt;
 
-    #[tokio::test]
-    async fn default() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut src = comp_buf.as_slice();
-                let mut r = AsyncBufReadDecompressor::new(&mut src).unwrap();
+    #[test]
+    fn default() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
                 assert_eq!(
-                    r.read_frame_info().await.unwrap().dict_id(),
-                    prefs.frame_info().dict_id()
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
                 );
-                r.read_to_end(&mut decomp_buf).await.unwrap();
-            }
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
-    }
-
-    #[tokio::test]
-    async fn dictionary() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            let dict = SmallRng::seed_from_u64(0)
-                .sample_iter(Standard)
-                .take(64_000)
-                .collect::<Vec<_>>();
-            {
-                let mut w = WriteCompressor::with_dict(
-                    &mut comp_buf,
-                    prefs,
-                    Dictionary::new(&dict).unwrap(),
-                )
-                .unwrap();
-                w.write_all(&src).unwrap();
-            }
-            {
-                let mut src = comp_buf.as_slice();
-                let mut r = AsyncBufReadDecompressor::new(&mut src).unwrap();
-                assert_eq!(
-                    r.read_frame_info().await.unwrap().dict_id(),
-                    prefs.frame_info().dict_id()
-                );
-                r.set_dict(&dict);
-                r.read_to_end(&mut decomp_buf).await.unwrap();
-            }
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
-    }
-
-    #[tokio::test]
-    async fn random_chunk() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = vec![0; src.len()];
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut src = comp_buf.as_slice();
-                let mut r = AsyncBufReadDecompressor::new(&mut src).unwrap();
-
-                let mut offset = 0;
-                let mut rng = SmallRng::seed_from_u64(0);
-
-                let dst_len = decomp_buf.len();
-                while offset < dst_len {
-                    let dst = &mut decomp_buf[offset..][..rng.gen_range(0, dst_len - offset + 1)];
-                    let len = r.read(dst).await.unwrap();
-                    assert!(dst.is_empty() || len > 0);
-                    offset += len;
+                {
+                    let mut src = comp_buf.as_slice();
+                    let mut r = AsyncBufReadDecompressor::new(&mut src).unwrap();
+                    assert_eq!(
+                        r.read_frame_info().await.unwrap().dict_id(),
+                        prefs.frame_info().dict_id()
+                    );
+                    r.read_to_end(&mut decomp_buf).await.unwrap();
                 }
-            }
-            assert_eq!(decomp_buf.len(), src.len());
-        }))
-        .await;
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
+    }
+
+    #[test]
+    fn dictionary() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                let dict = SmallRng::seed_from_u64(0)
+                    .sample_iter(Standard)
+                    .take(64_000)
+                    .collect::<Vec<_>>();
+                {
+                    let mut w = WriteCompressor::with_dict(
+                        &mut comp_buf,
+                        prefs,
+                        Dictionary::new(&dict).unwrap(),
+                    )
+                    .unwrap();
+                    w.write_all(&src).unwrap();
+                }
+                {
+                    let mut src = comp_buf.as_slice();
+                    let mut r = AsyncBufReadDecompressor::new(&mut src).unwrap();
+                    assert_eq!(
+                        r.read_frame_info().await.unwrap().dict_id(),
+                        prefs.frame_info().dict_id()
+                    );
+                    r.set_dict(&dict);
+                    r.read_to_end(&mut decomp_buf).await.unwrap();
+                }
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
+    }
+
+    #[test]
+    fn random_chunk() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = vec![0; src.len()];
+                assert_eq!(
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
+                );
+                {
+                    let mut src = comp_buf.as_slice();
+                    let mut r = AsyncBufReadDecompressor::new(&mut src).unwrap();
+
+                    let mut offset = 0;
+                    let mut rng = SmallRng::seed_from_u64(0);
+
+                    let dst_len = decomp_buf.len();
+                    while offset < dst_len {
+                        let dst =
+                            &mut decomp_buf[offset..][..rng.gen_range(0, dst_len - offset + 1)];
+                        let len = r.read(dst).await.unwrap();
+                        assert!(dst.is_empty() || len > 0);
+                        offset += len;
+                    }
+                }
+                assert_eq!(decomp_buf.len(), src.len());
+            }))
+            .await;
+        })
     }
 }
 
 mod async_write_decompressor {
     use super::*;
     use futures::future::join_all;
+    use futures_lite::AsyncWriteExt;
     use lzzzz::lz4f::{AsyncWriteDecompressor, WriteCompressor};
     use std::io::Write;
-    use tokio::io::AsyncWriteExt;
 
-    #[tokio::test]
-    async fn default() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
-                w.write_all(&comp_buf).await.unwrap();
-            }
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
-    }
-
-    #[tokio::test]
-    async fn decode_header_only() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
-                assert!(w.frame_info().is_none());
-                w.decode_header_only(true);
-
-                let mut header_len = 0;
-                while w.frame_info().is_none() {
-                    header_len += w.write(&comp_buf[header_len..]).await.unwrap();
-                }
-
-                assert_eq!(w.write(&comp_buf).await.unwrap(), 0);
-                w.decode_header_only(false);
-                w.write_all(&comp_buf[header_len..]).await.unwrap();
-            }
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
-    }
-
-    #[tokio::test]
-    async fn dictionary() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            let dict = SmallRng::seed_from_u64(0)
-                .sample_iter(Standard)
-                .take(64_000)
-                .collect::<Vec<_>>();
-            {
-                let mut w = WriteCompressor::with_dict(
-                    &mut comp_buf,
-                    prefs,
-                    Dictionary::new(&dict).unwrap(),
-                )
-                .unwrap();
-                w.write_all(&src).unwrap();
-            }
-            {
-                let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
-                w.set_dict(&dict);
-                w.write_all(&comp_buf).await.unwrap();
-            }
-            assert_eq!(decomp_buf, src);
-        }))
-        .await;
-    }
-
-    #[tokio::test]
-    async fn random_chunk() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
-
-                let mut offset = 0;
-                let mut rng = SmallRng::seed_from_u64(0);
-
-                while offset < comp_buf.len() {
-                    let src = &comp_buf[offset..][..rng.gen_range(0, comp_buf.len() - offset + 1)];
-                    let len = w.write(src).await.unwrap();
-                    assert!(src.is_empty() || len > 0);
-                    offset += len;
-                }
-            }
-            assert_eq!(decomp_buf.len(), src.len());
-        }))
-        .await;
-    }
-
-    #[tokio::test]
-    async fn invalid_header() {
-        join_all(lz4f_test_set().map(|(src, prefs)| async move {
-            let mut comp_buf = Vec::new();
-            let mut decomp_buf = Vec::new();
-            assert_eq!(
-                lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
-                comp_buf.len()
-            );
-            {
-                let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
-                let err = w
-                    .write_all(&comp_buf[1..])
-                    .await
-                    .unwrap_err()
-                    .into_inner()
-                    .unwrap()
-                    .downcast::<lz4f::Error>()
-                    .unwrap();
+    #[test]
+    fn default() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
                 assert_eq!(
-                    *err,
-                    lz4f::Error::Common(lzzzz::ErrorKind::FrameHeaderInvalid)
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
                 );
-            }
-        }))
-        .await;
+                {
+                    let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
+                    w.write_all(&comp_buf).await.unwrap();
+                }
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
+    }
+
+    #[test]
+    fn decode_header_only() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                assert_eq!(
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
+                );
+                {
+                    let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
+                    assert!(w.frame_info().is_none());
+                    w.decode_header_only(true);
+
+                    let mut header_len = 0;
+                    while w.frame_info().is_none() {
+                        header_len += w.write(&comp_buf[header_len..]).await.unwrap();
+                    }
+
+                    assert_eq!(w.write(&comp_buf).await.unwrap(), 0);
+                    w.decode_header_only(false);
+                    w.write_all(&comp_buf[header_len..]).await.unwrap();
+                }
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
+    }
+
+    #[test]
+    fn dictionary() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                let dict = SmallRng::seed_from_u64(0)
+                    .sample_iter(Standard)
+                    .take(64_000)
+                    .collect::<Vec<_>>();
+                {
+                    let mut w = WriteCompressor::with_dict(
+                        &mut comp_buf,
+                        prefs,
+                        Dictionary::new(&dict).unwrap(),
+                    )
+                    .unwrap();
+                    w.write_all(&src).unwrap();
+                }
+                {
+                    let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
+                    w.set_dict(&dict);
+                    w.write_all(&comp_buf).await.unwrap();
+                }
+                assert_eq!(decomp_buf, src);
+            }))
+            .await;
+        })
+    }
+
+    #[test]
+    fn random_chunk() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                assert_eq!(
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
+                );
+                {
+                    let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
+
+                    let mut offset = 0;
+                    let mut rng = SmallRng::seed_from_u64(0);
+
+                    while offset < comp_buf.len() {
+                        let src =
+                            &comp_buf[offset..][..rng.gen_range(0, comp_buf.len() - offset + 1)];
+                        let len = w.write(src).await.unwrap();
+                        assert!(src.is_empty() || len > 0);
+                        offset += len;
+                    }
+                }
+                assert_eq!(decomp_buf.len(), src.len());
+            }))
+            .await;
+        })
+    }
+
+    #[test]
+    fn invalid_header() {
+        smol::run(async {
+            join_all(lz4f_test_set().map(|(src, prefs)| async move {
+                let mut comp_buf = Vec::new();
+                let mut decomp_buf = Vec::new();
+                assert_eq!(
+                    lz4f::compress_to_vec(&src, &mut comp_buf, &prefs).unwrap(),
+                    comp_buf.len()
+                );
+                {
+                    let mut w = AsyncWriteDecompressor::new(&mut decomp_buf).unwrap();
+                    let err = w
+                        .write_all(&comp_buf[1..])
+                        .await
+                        .unwrap_err()
+                        .into_inner()
+                        .unwrap()
+                        .downcast::<lz4f::Error>()
+                        .unwrap();
+                    assert_eq!(
+                        *err,
+                        lz4f::Error::Common(lzzzz::ErrorKind::FrameHeaderInvalid)
+                    );
+                }
+            }))
+            .await;
+        })
     }
 }

--- a/tests/lz4f_async_stream.rs
+++ b/tests/lz4f_async_stream.rs
@@ -365,7 +365,7 @@ mod async_bufread_decompressor {
         })
     }
 
-    #[tokio::test]
+    #[test]
     async fn small_buffer() {
         join_all(lz4f_test_set().map(|(src, prefs)| async move {
             let mut comp_buf = Vec::new();


### PR DESCRIPTION
This is arguable but i think that using `async_std` and `futures` is preferable over tokio for the two following reasons:

Tokio futures are designed to be ran in a tokio executor and tend to panic / not work properly which makes them pretty hard to use. For instance the `smol` runtime [creates its own tokio executor](https://docs.rs/smol/0.3.3/smol/#compatibility) to circumvent this issue.

The `tokio` crate defines its own io traits which are incompatible the `futures-io` trais and therefore incompatible with any async library that isn't tokio (or based on). However, this gap can be bridge via a [tokio adapter](https://docs.rs/async-tungstenite/0.8.0/async_tungstenite/tokio/struct.TokioAdapter.html). I'm wondering if it would make sense to add another feature flag that also implements the tokio specific traits (we could reuse the tokio-io flag).

Also should I fill this PR against dev or master?