### PR TITLE
Added get_ref & get_mut to all compressors & decompressors

### DIFF
--- a/src/lz4f/stream/comp/async_bufread.rs
+++ b/src/lz4f/stream/comp/async_bufread.rs
@@ -81,6 +81,21 @@ impl<R: AsyncBufRead + Unpin> AsyncBufReadCompressor<R> {
         })
     }
 
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        &self.inner
+    }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+
     fn fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         let mut me = self.project();
         let inner_buf = match me.inner.as_mut().poll_fill_buf(cx) {

--- a/src/lz4f/stream/comp/async_read.rs
+++ b/src/lz4f/stream/comp/async_read.rs
@@ -62,6 +62,21 @@ impl<R: AsyncRead + Unpin> AsyncReadCompressor<R> {
             inner: AsyncBufReadCompressor::with_dict(BufReader::new(reader), prefs, dict)?,
         })
     }
+
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        self.inner.get_mut().get_mut()
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        self.inner.get_ref().get_ref()
+    }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.inner.into_inner().into_inner()
+    }
 }
 
 impl<R> fmt::Debug for AsyncReadCompressor<R>

--- a/src/lz4f/stream/comp/async_write.rs
+++ b/src/lz4f/stream/comp/async_write.rs
@@ -78,6 +78,21 @@ impl<W: AsyncWrite + Unpin> AsyncWriteCompressor<W> {
         })
     }
 
+    /// Returns a mutable reference to the writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Returns a shared reference to the writer.
+    pub fn get_ref(&mut self) -> &W {
+        &self.inner
+    }
+
+    /// Returns ownership of the writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+
     fn write_buffer(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let me = self.project();
         if let Poll::Ready(len) = me.inner.poll_write(cx, &me.comp.buf()[*me.consumed..])? {

--- a/src/lz4f/stream/comp/bufread.rs
+++ b/src/lz4f/stream/comp/bufread.rs
@@ -65,6 +65,16 @@ impl<R: BufRead> BufReadCompressor<R> {
     pub fn into_inner(self) -> R {
         self.inner
     }
+
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        &self.inner
+    }
 }
 
 impl<R> fmt::Debug for BufReadCompressor<R>

--- a/src/lz4f/stream/comp/read.rs
+++ b/src/lz4f/stream/comp/read.rs
@@ -55,6 +55,16 @@ impl<R: Read> ReadCompressor<R> {
     pub fn into_inner(self) -> R {
         self.inner.into_inner().into_inner()
     }
+
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        self.inner.get_mut().get_mut()
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        self.inner.get_ref().get_ref()
+    }
 }
 
 impl<R> fmt::Debug for ReadCompressor<R>

--- a/src/lz4f/stream/comp/write.rs
+++ b/src/lz4f/stream/comp/write.rs
@@ -47,6 +47,16 @@ impl<W: Write> WriteCompressor<W> {
         })
     }
 
+    /// Returns a mutable reference to the writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.inner.as_mut().unwrap()
+    }
+
+    /// Returns a shared reference to the writer.
+    pub fn get_ref(&mut self) -> &W {
+        self.inner.as_ref().unwrap()
+    }
+
     /// Returns the ownership of the writer, finishing the stream in the process.
     pub fn into_inner(mut self) -> W {
         let _ = self.end();

--- a/src/lz4f/stream/decomp/async_bufread.rs
+++ b/src/lz4f/stream/decomp/async_bufread.rs
@@ -94,6 +94,21 @@ impl<'a, R: AsyncBufRead + Unpin> AsyncBufReadDecompressor<'a, R> {
         }
     }
 
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        &self.inner
+    }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+
     fn fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         let mut me = self.project();
 

--- a/src/lz4f/stream/decomp/async_read.rs
+++ b/src/lz4f/stream/decomp/async_read.rs
@@ -74,6 +74,21 @@ impl<'a, R: AsyncRead + Unpin> AsyncReadDecompressor<'a, R> {
     pub async fn read_frame_info(&mut self) -> io::Result<FrameInfo> {
         self.inner.read_frame_info().await
     }
+
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        self.inner.get_mut().get_mut()
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        self.inner.get_ref().get_ref()
+    }
+
+    /// Returns ownership of the reader.
+    pub fn into_inner(self) -> R {
+        self.inner.into_inner().into_inner()
+    }
 }
 
 impl<R> fmt::Debug for AsyncReadDecompressor<'_, R>

--- a/src/lz4f/stream/decomp/async_write.rs
+++ b/src/lz4f/stream/decomp/async_write.rs
@@ -91,6 +91,21 @@ impl<'a, W: AsyncWrite + Unpin> AsyncWriteDecompressor<'a, W> {
         self.decomp.decode_header_only(flag);
     }
 
+    /// Returns a mutable reference to the writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Returns a shared reference to the writer.
+    pub fn get_ref(&mut self) -> &W {
+        &self.inner
+    }
+
+    /// Returns ownership of the writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+
     fn write_buffer(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let me = self.project();
         if let Poll::Ready(len) = me.inner.poll_write(cx, &me.decomp.buf()[*me.consumed..])? {

--- a/src/lz4f/stream/decomp/bufread.rs
+++ b/src/lz4f/stream/decomp/bufread.rs
@@ -82,6 +82,16 @@ impl<'a, R: BufRead> BufReadDecompressor<'a, R> {
     pub fn into_inner(self) -> R {
         self.inner
     }
+
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        &self.inner
+    }
 }
 
 impl<R> fmt::Debug for BufReadDecompressor<'_, R>

--- a/src/lz4f/stream/decomp/read.rs
+++ b/src/lz4f/stream/decomp/read.rs
@@ -78,6 +78,16 @@ impl<'a, R: Read> ReadDecompressor<'a, R> {
     pub fn into_inner(self) -> R {
         self.inner.into_inner().into_inner()
     }
+
+    /// Returns a mutable reference to the reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        self.inner.get_mut().get_mut()
+    }
+
+    /// Returns a shared reference to the reader.
+    pub fn get_ref(&mut self) -> &R {
+        self.inner.get_ref().get_ref()
+    }
 }
 
 impl<R: Read> Read for ReadDecompressor<'_, R> {

--- a/src/lz4f/stream/decomp/write.rs
+++ b/src/lz4f/stream/decomp/write.rs
@@ -64,6 +64,16 @@ impl<'a, W: Write> WriteDecompressor<'a, W> {
         self.decomp.decode_header_only(flag);
     }
 
+    /// Returns a mutable reference to the writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Returns a shared reference to the writer.
+    pub fn get_ref(&mut self) -> &W {
+        &self.inner
+    }
+
     /// Returns ownership of the writer.
     pub fn into_inner(self) -> W {
         self.inner


### PR DESCRIPTION
Now that I think about it, I'm not sure how I feel about `CompressorWriter::into_inner` because its possible that the writer is blocking. This would make `into_inner` block, which would be unexpected for the user.
https://github.com/picoHz/lzzzz/blob/8b58d544db8b857907d6a75f64f9b5cab3924890/src/lz4f/stream/comp/write.rs#L50-L54

I kind feel the same for the `Drop` impl of `CompressorWriter` which could also potentially block.
https://github.com/picoHz/lzzzz/blob/8b58d544db8b857907d6a75f64f9b5cab3924890/src/lz4f/stream/comp/write.rs#L95-L99

A potential solution would be to expose a separate `fn finish(self) -> Result<(), io::Error>` method,  however it would be easy for the user to misuse the API since `Write` doesn't implement a `close` method like `AsyncWrite` does.