### PR TITLE
Fix async writers wakeups, flushing and closing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rand = { version = "0.7.3", features = ["small_rng"] }
 rayon = "1.3.1"
 static_assertions = "1.1.0"
 smol = "0.3.3"
+futures-test = "0.3.5"
 
 [build-dependencies]
 cc = { version = "1.0.58", features = ["parallel"] }

--- a/src/lz4f/stream/comp/async_bufread.rs
+++ b/src/lz4f/stream/comp/async_bufread.rs
@@ -87,7 +87,7 @@ impl<R: AsyncBufRead + Unpin> AsyncBufReadCompressor<R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         &self.inner
     }
 

--- a/src/lz4f/stream/comp/async_read.rs
+++ b/src/lz4f/stream/comp/async_read.rs
@@ -69,7 +69,7 @@ impl<R: AsyncRead + Unpin> AsyncReadCompressor<R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         self.inner.get_ref().get_ref()
     }
 

--- a/src/lz4f/stream/comp/bufread.rs
+++ b/src/lz4f/stream/comp/bufread.rs
@@ -72,7 +72,7 @@ impl<R: BufRead> BufReadCompressor<R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         &self.inner
     }
 }

--- a/src/lz4f/stream/comp/read.rs
+++ b/src/lz4f/stream/comp/read.rs
@@ -62,7 +62,7 @@ impl<R: Read> ReadCompressor<R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         self.inner.get_ref().get_ref()
     }
 }

--- a/src/lz4f/stream/comp/write.rs
+++ b/src/lz4f/stream/comp/write.rs
@@ -53,7 +53,7 @@ impl<W: Write> WriteCompressor<W> {
     }
 
     /// Returns a shared reference to the writer.
-    pub fn get_ref(&mut self) -> &W {
+    pub fn get_ref(&self) -> &W {
         self.inner.as_ref().unwrap()
     }
 

--- a/src/lz4f/stream/decomp/async_bufread.rs
+++ b/src/lz4f/stream/decomp/async_bufread.rs
@@ -100,7 +100,7 @@ impl<'a, R: AsyncBufRead + Unpin> AsyncBufReadDecompressor<'a, R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         &self.inner
     }
 

--- a/src/lz4f/stream/decomp/async_read.rs
+++ b/src/lz4f/stream/decomp/async_read.rs
@@ -81,7 +81,7 @@ impl<'a, R: AsyncRead + Unpin> AsyncReadDecompressor<'a, R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         self.inner.get_ref().get_ref()
     }
 

--- a/src/lz4f/stream/decomp/bufread.rs
+++ b/src/lz4f/stream/decomp/bufread.rs
@@ -89,7 +89,7 @@ impl<'a, R: BufRead> BufReadDecompressor<'a, R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         &self.inner
     }
 }

--- a/src/lz4f/stream/decomp/read.rs
+++ b/src/lz4f/stream/decomp/read.rs
@@ -85,7 +85,7 @@ impl<'a, R: Read> ReadDecompressor<'a, R> {
     }
 
     /// Returns a shared reference to the reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         self.inner.get_ref().get_ref()
     }
 }

--- a/src/lz4f/stream/decomp/write.rs
+++ b/src/lz4f/stream/decomp/write.rs
@@ -70,7 +70,7 @@ impl<'a, W: Write> WriteDecompressor<'a, W> {
     }
 
     /// Returns a shared reference to the writer.
-    pub fn get_ref(&mut self) -> &W {
+    pub fn get_ref(&self) -> &W {
         &self.inner
     }
 


### PR DESCRIPTION
This fixes #5 by fixing the state machine of both `AsyncWriteCompressor` and `AsyncWriteDecompressor`. New tests were also added.