### PR TITLE
cast to c_char instead of i8

### DIFF
--- a/src/lz4/block/api.rs
+++ b/src/lz4/block/api.rs
@@ -30,7 +30,7 @@ pub fn compress_fast_ext_state(
         binding::LZ4_compress_fast_extState(
             state.as_mut_ptr() as *mut c_void,
             src.as_ptr() as *const c_char,
-            dst as *mut i8,
+            dst as *mut c_char,
             src.len() as c_int,
             dst_len as c_int,
             acceleration as c_int,
@@ -49,7 +49,7 @@ pub fn compress_fast_ext_state_fast_reset(
         binding::LZ4_compress_fast_extState_fastReset(
             state.as_mut_ptr() as *mut c_void,
             src.as_ptr() as *const c_char,
-            dst as *mut i8,
+            dst as *mut c_char,
             src.len() as c_int,
             dst_len as c_int,
             acceleration as c_int,


### PR DESCRIPTION
Cast to c_char instead of i8 to support ARM. See similar issue [here](https://github.com/remacs/remacs/issues/1393).