### PR TITLE
include LICENSE file in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/picoHz/lzzzz"
 documentation = "https://docs.rs/lzzzz"
 license = "MIT"
 readme = "README.md"
-include = ["src/**/*", "build.rs", "vendor/liblz4/*", "Cargo.toml"]
+include = ["src/**/*", "build.rs", "vendor/liblz4/*", "Cargo.toml","LICENSE"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I am trying to package this for fedora, and it would be simpler if the crate includes the LICENSE file to the source published to crates.io.

Also, the MIT License requires the license text to be distributed along with the source code so even on crates.io