### PR TITLE
Add `compress_fill` to allow use of `LZ4_compress_destSize`

### DIFF
--- a/src/lz4/binding.rs
+++ b/src/lz4/binding.rs
@@ -34,6 +34,12 @@ extern "C" {
         dst_capacity: c_int,
         acceleration: c_int,
     ) -> c_int;
+    pub fn LZ4_compress_destSize(
+        src: *const c_char,
+        dst: *mut c_char,
+        src_size: *mut c_int,
+        target_dst_size: c_int,
+    ) -> c_int;
     pub fn LZ4_decompress_safe(
         src: *const c_char,
         dst: *mut c_char,

--- a/src/lz4/block/api.rs
+++ b/src/lz4/block/api.rs
@@ -57,6 +57,26 @@ pub fn compress_fast_ext_state_fast_reset(
     }
 }
 
+pub fn compress_dest_size(
+    src: &[u8],
+    dst: &mut [u8],
+) -> Result<(usize, usize)> {
+    let mut src_size: c_int = src.len() as c_int;
+    let result = unsafe {
+        binding::LZ4_compress_destSize(
+            src.as_ptr() as *const c_char,
+            dst.as_mut_ptr() as *mut c_char,
+            &mut src_size as *mut c_int,
+            dst.len() as c_int,
+        )
+    };
+    if result == 0 {
+        Err(Error::new(ErrorKind::CompressionFailed))
+    } else {
+        Ok((src_size as usize, result as usize))
+    }
+}
+
 pub fn decompress_safe(src: &[u8], dst: &mut [u8]) -> Result<usize> {
     let result = unsafe {
         binding::LZ4_decompress_safe(

--- a/src/lz4_hc/block/mod.rs
+++ b/src/lz4_hc/block/mod.rs
@@ -56,6 +56,60 @@ fn compress_to_ptr(src: &[u8], dst: *mut u8, dst_len: usize, level: i32) -> Resu
     }
 }
 
+/// Compress data to fill `dst`.
+///
+/// This function either compresses the entire `src` buffer into `dst` if it's
+/// large enough, or will fill `dst` with as much data as possible from `src`.
+///
+/// Returns a pair `(read, wrote)` giving the number of bytes read from `src`
+/// and the number of bytes written to `dst`.
+///
+/// # Example
+///
+/// ```
+/// use lzzzz::{lz4, lz4_hc};
+///
+/// let data = b"The quick brown fox jumps over the lazy dog.";
+/// let mut buf = [0u8; 256];
+///
+/// // This slice should have enough capacity.
+/// assert!(buf.len() >= lz4::max_compressed_size(data.len()));
+///
+/// let (read, wrote) = lz4_hc::compress_fill(data, &mut buf, lz4_hc::CLEVEL_DEFAULT)?;
+/// assert_eq!(read, data.len());
+/// let compressed = &buf[..wrote];
+///
+/// # let mut buf = [0u8; 256];
+/// # let len = lz4::decompress(compressed, &mut buf[..data.len()])?;
+/// # assert_eq!(&buf[..len], &data[..]);
+///
+/// // This slice doesn't have enough capacity, but we can fill it.
+/// let mut smallbuf = [0u8; 32];
+/// assert!(smallbuf.len() < lz4::max_compressed_size(data.len()));
+///
+/// let (read, wrote) = lz4_hc::compress_fill(data, &mut smallbuf, lz4_hc::CLEVEL_DEFAULT)?;
+/// assert_eq!(wrote, smallbuf.len());
+/// let remaining_data = &data[read..];
+///
+/// # let mut buf = [0u8; 256];
+/// # let len = lz4::decompress(&smallbuf, &mut buf)?;
+/// # assert_eq!(&buf[..len], &data[..read]);
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub fn compress_fill(src: &[u8], dst: &mut [u8], level: i32) -> Result<(usize, usize)> {
+    if src.is_empty() {
+        return Ok((0,0))
+    }
+    let (read, wrote) = ExtState::with(|state, _reset| {
+        api::compress_dest_size(&mut state.borrow_mut(), src, dst, level)
+    });
+    if wrote > 0 {
+        Ok((read, wrote))
+    } else {
+        Err(Error::new(ErrorKind::CompressionFailed))
+    }
+}
+
 /// Compresses data until the destination slice fills up.
 ///
 /// Returns the number of bytes written into the destination buffer.

--- a/tests/lz4.rs
+++ b/tests/lz4.rs
@@ -18,6 +18,22 @@ mod compress {
             assert_eq!(decomp_buf, src);
         });
     }
+
+    #[test]
+    fn fill() {
+        lz4_test_set()
+            .flat_map(|(src, mode)| (0..20).map(move |n| (src.clone(), mode, 16 << n)))
+            .par_bridge()
+            .for_each(|(src, _mode, len)| {
+                let mut comp_buf = vec![0; len];
+                let mut decomp_buf = Vec::new();
+                let (read, wrote) = lz4::compress_fill(&src, &mut comp_buf).unwrap();
+                decomp_buf.resize(read, 0);
+                let len = lz4::decompress(&comp_buf[..wrote], &mut decomp_buf).unwrap();
+                assert_eq!(len, read);
+                assert!(src.starts_with(&decomp_buf));
+            });
+    }
 }
 
 mod compress_to_vec {


### PR DESCRIPTION
lzzzz provides an excellent Rust API for liblz4, but it didn't expose `LZ4_compress_destSize` anywhere for people like me to use. These patches fix that.

Changes to lzzzz's public API are as follows:

* adds `lz4::compress_fill`, which gives a Rust interface to `LZ4_compress_destSize`
* adds `lz4::compress_partial` for consistency with the existing `lz4_hc::compress_partial`
* adds `lz4_hc::compress_fill` for consistency with `lz4::compress_fill`

I called it `compress_fill` because `compress_fill(src, dst)` seemed clearer than `compress_destsize(src, dst)`, but I'm fine with changing the name if you'd prefer something else (maybe `compress_filldest(src, dst)`?).

Also, if you'd prefer to only add `lz4::compress_fill`, I'd be happy to send a patch without the other two functions.

Thanks!